### PR TITLE
Add a package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,16 @@
+import { readdirSync } from 'fs';
+import { join } from 'path'
+const __dirname = import.meta.dirname;
+
+function getCoreList() {
+    let output = []
+    const files = readdirSync(join(__dirname, 'retroarch'));
+    for (let file of files) {
+        if (file.includes('_libretro.js')) {
+            output.push(file.replace('_libretro.js', ''));
+        }
+    }
+    return output;
+}
+
+export { getCoreList };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@arianrhodsandlot/retroarch-emscripten-build",
+  "version": "1.20.1",
+  "description": "Contains RetroArch builds for emscripten.",
+  "main": "index.mjs",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/arianrhodsandlot/retroarch-emscripten-build.git"
+  },
+  "scripts": {
+    "update-build": "python update.py",
+    "test": "node test/index.mjs"
+  },
+  "type": "module",
+  "author": "arianrhodsandlot",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/arianrhodsandlot/retroarch-emscripten-build/issues"
+  },
+  "homepage": "https://github.com/arianrhodsandlot/retroarch-emscripten-build#readme"
+}

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -1,0 +1,7 @@
+import assert from 'node:assert/strict';
+import { getCoreList } from '../index.mjs';
+
+const cores = getCoreList();
+
+assert.ok(cores.includes('fceumm'));
+assert.ok(cores.length > 10);


### PR DESCRIPTION
Not sure if this is the direction you'd like this repo to go, but I thought it would be great to have npm download the files through package.json definition:

```json
{
  "dependencies": {
    "retroarch-emscsripten-build": "git+https://github.com/arianrhodsandlot/retroarch-emscripten-build.git"
  }
}
```

It also adds an index file that lists the available cores and a `npm test` script to make sure it works. If this isn't what you'd like to be in here, I'm okay with you closing this PR. Thanks!

``` js
import { getCoreList } from '../index.mjs';
const cores = getCoreList();
```
